### PR TITLE
Linux include path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 *.tar.gz
+lpsolve

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Golp is a Golang wrapper for the [LPSolve](http://lpsolve.sourceforge.net/5.5/) 
 **Step 1: Get the golp Go code**
 
 ```
-go get github.com/draffensperger/golp
+go get -d github.com/draffensperger/golp
 ```
 
 **Step 2: Get the LPSolve library**
@@ -27,7 +27,7 @@ Here's how you could download and extract the LPSolve library for 64-bit Linux:
 ```
 LP_URL=http://sourceforge.net/projects/lpsolve/files/lpsolve/5.5.2.0/lp_solve_5.5.2.0_dev_ux64.tar.gz
 LP_DIR=$GOPATH/src/github.com/draffensperger/golp/lpsolve
-mkdir -p $GOPATH/lpsolve
+mkdir -p $LP_DIR
 curl -L $LP_URL | tar xvz -C $LP_DIR
 ```
 

--- a/lp.go
+++ b/lp.go
@@ -25,8 +25,8 @@ package golp
 #cgo darwin LDFLAGS: -L/opt/local/lib -llpsolve55
 
 // For Linux, assume LPSolve bundled in local lpsolve directory
-#cgo linux CFLAGS: -I./lpsolve
-#cgo linux LDFLAGS: -L./lpsolve -llpsolve55 -Wl,-rpath=./lpsolve
+#cgo linux CFLAGS: -I${SRCDIR}/lpsolve
+#cgo linux LDFLAGS: -L${SRCDIR}/lpsolve -llpsolve55 -Wl,-rpath=${SRCDIR}/lpsolve
 
 #include "lp_lib.h"
 #include <stdlib.h>


### PR DESCRIPTION
The cgo flags for linux were set to
```go
#cgo linux CFLAGS: -I./lpsolve
#cgo linux LDFLAGS: -L./lpsolve -llpsolve55 -Wl,-rpath=./lpsolve
```
It seems that if you want to use golp inside a different project it is not sufficient to put lpsolve in `$GOPATH/src/github.com/draffensperger/golp/lpsolve`. Instead it must be placed alongside the go source file. That is a problem if you have a `cmd` directory with subdirectories for different commands (because each one requires lpsolve in it). Also in each `tests` directory lpsolve must be copied. The [cgo documentation](https://golang.org/cmd/cgo/) states that

> [...]  `${SRCDIR}` will be replaced by the absolute path to the directory containing the source file

Thus changing the path to `${SRCDIR}/lpsolve` should fix the issue and lpsolve must only reside in `$GOPATH/src/github.com/draffensperger/golp/lpsolve`.