### PR TITLE
Update Travis build to check 1.7, 1.8 and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_install:
 - mkdir lpsolve
 - curl -L https://sourceforge.net/projects/lpsolve/files/lpsolve/5.5.2.0/lp_solve_5.5.2.0_dev_ux64.tar.gz | tar xvz -C lpsolve
 go:
-- 1.4
-- 1.5
+- 1.7
+- 1.8
 - tip
 notifications:
   email: false


### PR DESCRIPTION
This should enable https://github.com/draffensperger/golp/pull/7 to build successfully.