### PR TITLE
Fix Duals() to retrive correct length of duals array

### DIFF
--- a/lp.go
+++ b/lp.go
@@ -477,14 +477,12 @@ func (l *LP) Variables() []float64 {
 // Duals should be called only after Solve() is successful.
 // See https://lpsolve.sourceforge.net/5.5/get_sensitivity_rhs.htm
 func (l *LP) Duals() []float64 {
-
 	numRows := int(C.get_Nrows(l.ptr))
-	numCols := int(C.get_Ncolumns(l.ptr))
 
-	cRow := make([]C.double, numRows+numCols+1)
+	cRow := make([]C.double, numRows+1)
 	C.get_dual_solution(l.ptr, &cRow[0])
-	row := make([]float64, numCols)
-	for i := 0; i < numCols; i++ {
+	row := make([]float64, numRows)
+	for i := 0; i < numRows; i++ {
 		// value index 0 is not used and only values
 		// from index 1 onward are considered
 		row[i] = float64(cRow[i+1])

--- a/lp_test.go
+++ b/lp_test.go
@@ -36,10 +36,8 @@ func TestLP(t *testing.T) {
 	assert.InDelta(t, 21.875, vars[0], delta)
 	assert.InDelta(t, 53.125, vars[1], delta)
 
-	duals := lp.Duals()
-	assert.Equal(t, len(duals), 2)
-	assert.InDelta(t, 0, duals[0], delta)
-	assert.InDelta(t, 1.0375, duals[1], delta)
+	assert.InDelta(t, 0.0, lp.DualResult(0), delta)
+	assert.InDelta(t, 1.0375, lp.DualResult(1), delta)
 }
 
 // TestMIP tests a mixed-integer programming example
@@ -68,8 +66,11 @@ func TestMIP(t *testing.T) {
 	assert.InDelta(t, 2.0, vars[2], delta)
 	assert.InDelta(t, 0.0, vars[3], delta)
 
-	assert.InDelta(t, -1.6666666666, lp.DualResult(0), delta)
-	assert.InDelta(t, 0.3333333333, lp.DualResult(1), delta)
-	assert.InDelta(t, 0.0, lp.DualResult(2), delta)
-	assert.InDelta(t, 0.0, lp.DualResult(3), delta)
+	duals := lp.Duals()
+	assert.Len(t, duals, 5)
+	assert.InDelta(t, -1.6666666666, duals[0], delta)
+	assert.InDelta(t, 0.3333333333, duals[1], delta)
+	assert.InDelta(t, 0.0, duals[2], delta)
+	assert.InDelta(t, 0.0, duals[3], delta)
+	assert.InDelta(t, 0.0, duals[4], delta)
 }


### PR DESCRIPTION
This PR fixes a bug I introduced earlier in PR #18 in the `Duals()` function. 

In that PR I confused `len(rows)` and `len(cols)` and was retrieving duals from resulting array for the length of columns, while in fact duals are produced for rows. 

This fixes the tests as well. By accident the test that should have been validating this had equal rows and cols, so didn't throw an error. This PR fixes that as well.